### PR TITLE
Load more on initial load; don't wait for first scroll. Fixes #2

### DIFF
--- a/dist/infinite-scroll.js
+++ b/dist/infinite-scroll.js
@@ -1,10 +1,10 @@
 "use strict";
 
 module.exports = function (_ref) {
-  var _ref$distance = _ref.distance;
-  var distance = _ref$distance === undefined ? 50 : _ref$distance;
-  var _ref$disableCallback = _ref.disableCallback;
-  var disableCallback = _ref$disableCallback === undefined ? false : _ref$disableCallback;
+  var _ref$distance = _ref.distance,
+      distance = _ref$distance === undefined ? 50 : _ref$distance,
+      _ref$disableCallback = _ref.disableCallback,
+      disableCallback = _ref$disableCallback === undefined ? false : _ref$disableCallback;
 
   function getScrollPos() {
     if (self.pageYOffset) {
@@ -47,6 +47,8 @@ module.exports = function (_ref) {
       options: { distance: distance },
       isUpdating: false
     };
+
+    handleScroll(scroller);
 
     window.onscroll = function (event) {
       handleScroll(scroller, event);

--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -44,6 +44,8 @@ module.exports = function({
       isUpdating: false
     };
 
+    handleScroll(scroller);
+
     window.onscroll = (event) => {
       handleScroll(scroller, event);
     };


### PR DESCRIPTION
Pretend a scroll has happened at once when everscroll loads. Fixes #2 